### PR TITLE
Revert "Increase font size to 16"

### DIFF
--- a/editor-font.xml
+++ b/editor-font.xml
@@ -1,8 +1,8 @@
 <application>
   <component name="DefaultFont">
     <option name="VERSION" value="1" />
-    <option name="FONT_SIZE" value="16" />
-    <option name="FONT_SIZE_2D" value="16.0" />
+    <option name="FONT_SIZE" value="15" />
+    <option name="FONT_SIZE_2D" value="15.0" />
     <option name="FONT_FAMILY" value="DejaVu Sans Mono" />
     <option name="FONT_REGULAR_SUB_FAMILY" value="Book" />
   </component>


### PR DESCRIPTION
It turns out that on smaller Monitors and built-in laptops screen with font size 16 two instances of the CLion or one instance of Clion on half a screen don't fit into the side-by-side layout. 
Therefore reverting font size to 15 by defdault.
This reverts commit f06f56f094c8a15283e45ba110a3bd2298bda12e.