### PR TITLE
Add `Generate requirements report` action and button

### DIFF
--- a/_bazel_build_html_requirements.sh
+++ b/_bazel_build_html_requirements.sh
@@ -6,4 +6,4 @@
 set -ex
 bazel run //apex_internal/tools/apex_doc_tools:apex_doc -- requirements
 
-firefox ../reqs/build/index.html&
+xdg-open doc/internal/build/index.html&

--- a/_bazel_build_html_requirements.sh
+++ b/_bazel_build_html_requirements.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Apex.AI, Inc.
+# All rights reserved.
+
+set -ex
+bazel run //apex_internal/tools/apex_doc_tools:apex_doc -- requirements
+
+firefox ../reqs/build/index.html&

--- a/customization.xml
+++ b/customization.xml
@@ -208,19 +208,49 @@
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Allocation Analyzer" is_action="true" action_type="1" position="18">
+    <group value="Tool_External Tools_Generate requirements report" is_action="true" action_type="1" position="18">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Markdown linter" is_action="true" action_type="1" position="19">
+    <group value="Tool_External Tools_Allocation Analyzer" is_action="true" action_type="1" position="19">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Markdown linter fix" is_action="true" action_type="1" position="20">
+    <group value="Tool_External Tools_Markdown linter" is_action="true" action_type="1" position="20">
+      <path value="root" />
+      <path value="Main Toolbar" />
+      <path value="Toolbar Run Actions" />
+      <option name="myInitialPosition" value="-1" />
+    </group>
+    <group value="Tool_External Tools_Markdown linter fix" is_action="true" action_type="1" position="21">
+      <path value="root" />
+      <path value="Main Toolbar" />
+      <path value="Toolbar Run Actions" />
+      <option name="myInitialPosition" value="-1" />
+    </group>
+    <group seperator="true" action_type="1" position="22">
+      <path value="root" />
+      <path value="Main Toolbar" />
+      <path value="Toolbar Run Actions" />
+      <option name="myInitialPosition" value="-1" />
+    </group>
+    <group value="Tool_External Tools_Build Current" is_action="true" action_type="1" position="23">
+      <path value="root" />
+      <path value="Main Toolbar" />
+      <path value="Toolbar Run Actions" />
+      <option name="myInitialPosition" value="-1" />
+    </group>
+    <group value="Tool_External Tools_Build Up To Current" is_action="true" action_type="1" position="24">
+      <path value="root" />
+      <path value="Main Toolbar" />
+      <path value="Toolbar Run Actions" />
+      <option name="myInitialPosition" value="-1" />
+    </group>
+    <group value="Tool_External Tools_Test Current" is_action="true" action_type="1" position="25">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
@@ -243,6 +273,7 @@
     <action id="Tool_External Tools_Test Current" icon="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/icons/Colcon_TestPkg.png" />
     <action id="Tool_External Tools_Test Current (Retest until fail)" icon="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/icons/RetestUntilFail.png" />
     <action id="Tool_External Tools_Clang Reformat Bazel" icon="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/icons/Clang_Format.png" />
+    <action id="Tool_External Tools_Generate requirements report" icon="Vcs.Log.AnnotateRevisionAction" />
     <action id="Tool_External Tools_Build Up To Current" icon="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/icons/Colcon_BuildUpTo.png" />
     <action id="Tool_External Tools_Doc linters" icon="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/icons/Doc_Linters.png" />
     <action id="Tool_External Tools_Clang Reformat" icon="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/icons/Clang_Format.png" />

--- a/customization.xml
+++ b/customization.xml
@@ -196,61 +196,55 @@
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Insert and verify test id(s) Current" is_action="true" action_type="1" position="16">
+    <group value="Tool_External Tools_VectorCAST coverage Current" is_action="true" action_type="1" position="16">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_VectorCAST coverage Current" is_action="true" action_type="1" position="17">
+    <group value="Tool_External Tools_Generate requirements report" is_action="true" action_type="1" position="17">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Generate requirements report" is_action="true" action_type="1" position="18">
+    <group value="Tool_External Tools_Allocation Analyzer" is_action="true" action_type="1" position="18">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Allocation Analyzer" is_action="true" action_type="1" position="19">
+    <group value="Tool_External Tools_Markdown linter" is_action="true" action_type="1" position="19">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Markdown linter" is_action="true" action_type="1" position="20">
+    <group value="Tool_External Tools_Markdown linter fix" is_action="true" action_type="1" position="20">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Markdown linter fix" is_action="true" action_type="1" position="21">
+    <group seperator="true" action_type="1" position="21">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group seperator="true" action_type="1" position="22">
+    <group value="Tool_External Tools_Build Current" is_action="true" action_type="1" position="22">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Build Current" is_action="true" action_type="1" position="23">
+    <group value="Tool_External Tools_Build Up To Current" is_action="true" action_type="1" position="23">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />
       <option name="myInitialPosition" value="-1" />
     </group>
-    <group value="Tool_External Tools_Build Up To Current" is_action="true" action_type="1" position="24">
-      <path value="root" />
-      <path value="Main Toolbar" />
-      <path value="Toolbar Run Actions" />
-      <option name="myInitialPosition" value="-1" />
-    </group>
-    <group value="Tool_External Tools_Test Current" is_action="true" action_type="1" position="25">
+    <group value="Tool_External Tools_Test Current" is_action="true" action_type="1" position="24">
       <path value="root" />
       <path value="Main Toolbar" />
       <path value="Toolbar Run Actions" />

--- a/tools/External Tools.xml
+++ b/tools/External Tools.xml
@@ -126,6 +126,13 @@
       <option name="WORKING_DIRECTORY" value="$ProjectFileDir$/.." />
     </exec>
   </tool>
+  <tool name="Insert and verify test id(s) Current" description="Insert and verify the unique test id" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
+    <exec>
+      <option name="COMMAND" value="identify_test_uid" />
+      <option name="PARAMETERS" value="insert $FilePath$" />
+      <option name="WORKING_DIRECTORY" value="$FileDir$" />
+    </exec>
+  </tool>
   <tool name="VectorCAST coverage Current" description="Create VectorCAST coverage report on currently loaded package" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
     <exec>
       <option name="COMMAND" value="_apex_clion_vc_coverage" />
@@ -133,11 +140,11 @@
       <option name="WORKING_DIRECTORY" value="$ProjectFileDir$/.." />
     </exec>
   </tool>
-  <tool name="Insert and verify test id(s) Current" description="Insert and verify the unique test id" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
+  <tool name="Generate requirements report" description="Build the html pages containing requirements" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
     <exec>
-      <option name="COMMAND" value="identify_test_uid" />
-      <option name="PARAMETERS" value="insert $FilePath$" />
-      <option name="WORKING_DIRECTORY" value="$FileDir$" />
+      <option name="COMMAND" value="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/_bazel_build_html_requirements.sh" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$ProjectFileDir$/.." />
     </exec>
   </tool>
   <tool name="Allocation Analyzer" description="Run Alloc analyzer on current project + current target" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">


### PR DESCRIPTION
- The new command will rebuild sphinx-needs html report and open it in Firefox (the default browser in ADE).
- Also added buttons for the colcon build, build up until current and test current package.