### PR TITLE
Fix for Markdown linter buttons to be able to correctly work with bazel

### DIFF
--- a/_markdown_linter.sh
+++ b/_markdown_linter.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Apex.AI, Inc.
+# All rights reserved.
+
+if [[ -n "$1" ]]; then
+    FILE_PATH="$1" # $FilePath$
+    shift
+else
+    echo "Error: The script shall be called with '\$FilePath\$' as parameter."
+    echo "Expected usage: _markdown_linter.sh '\$FilePath\$' ['\$WorkspaceRoot\$'] [--fix]"
+    exit 1
+fi
+
+if [ -n "$1" ] && [ -d "$1" ]; then
+    WORKSPACE_ROOT="$1/"
+    shift
+elif [ -n "$1" ] && [ "$1" == "\$WorkspaceRoot\$" ]; then
+    shift
+    # Ignor this parameter for Colcon/CMake
+fi
+
+if [ -n "$1" ] && [ "$1" == "--fix" ]; then
+    if [ "$1" == "--fix" ]; then
+        FIX="$1"
+        shift
+    else
+        echo "Error: Found unexpected parameter: $1"
+    fi
+fi
+
+set -ex
+markdownlint -c $WORKSPACE_ROOT../../.markdownlint.yaml $FIX $FILE_PATH

--- a/tools/External Tools.xml
+++ b/tools/External Tools.xml
@@ -156,15 +156,15 @@
   </tool>
   <tool name="Markdown linter" description="Run markdown linter on the current file" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
     <exec>
-      <option name="COMMAND" value="markdownlint" />
-      <option name="PARAMETERS" value="-c ../../.markdownlint.yaml $FilePath$" />
+      <option name="COMMAND" value="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/_markdown_linter.sh" />
+      <option name="PARAMETERS" value="$FilePath$ $WorkspaceRoot$" />
       <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     </exec>
   </tool>
   <tool name="Markdown linter fix" description="Run markdown linter on the current file and fix the violations" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
     <exec>
-      <option name="COMMAND" value="markdownlint" />
-      <option name="PARAMETERS" value="-c ../../.markdownlint.yaml --fix $FilePath$" />
+      <option name="COMMAND" value="$APPLICATION_CONFIG_DIR$/settingsRepository/repository/_markdown_linter.sh" />
+      <option name="PARAMETERS" value="$FilePath$ $WorkspaceRoot$ --fix" />
       <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     </exec>
   </tool>


### PR DESCRIPTION
Fix for Markdown linter buttons to be able to correctly work with Bazel
Added `_markdown_linter.sh` wrapper script to support both Baazel and CMake/Colcon

When the Bazel plugin is enabled there are defined `$WorkspaceRoot$` variable which point directly to the `apex_ws/src` folder. 
When the Bazel plugin is disabled the `$WorkspaceRoot$` variable is not defined and the script will properly take it into account and fall back to the old behavior.