### PR TITLE
Add "strict_gcc" flag to the "Build Current Bazel" to match CI config

### DIFF
--- a/_bazel_build_current_pkg.sh
+++ b/_bazel_build_current_pkg.sh
@@ -16,7 +16,9 @@ if [ -n "$PACKAGE" ]; then
     set -ex
     bazel build //$PACKAGE:all \
 	--output_filter= \
-	--strip=never
+	--strip=never \
+  --platforms=//:gcc9-x86_64 \
+  --config=strict_gcc
 else
     echo "Error: can't find package for $FILE_PATH file."
 fi


### PR DESCRIPTION
- Follow up on the https://gitlab.apex.ai/ApexAI/grand_central/-/merge_requests/13315

- We introduced -Werror for Bazel in CI for all compilers recently and to match this config for local build need to use `--config=strict_gcc` flag for gcc compiler.