### PR TITLE
Some new changes and improvements

### DIFF
--- a/_bazel_sca_current_pkg.sh
+++ b/_bazel_sca_current_pkg.sh
@@ -14,7 +14,7 @@ fi
 
 if [ -n "$PACKAGE" ]; then
     set -ex
-    bazel build --config=axivion //$PACKAGE
+    bazel build --config=axivion //$PACKAGE:all
 else
     echo "Error: can't find package for $FILE_PATH file."
 fi

--- a/_bazel_test_current_pkg.sh
+++ b/_bazel_test_current_pkg.sh
@@ -27,7 +27,8 @@ if [ -n "$PACKAGE" ]; then
 	--runs_per_test=$RERUN \
 	--test_keep_going \
 	--test_summary=detailed \
-	--test_output=all
+	--test_output=all \
+	--test_verbose_timeout_warnings
 else
     echo "Error: can't find package for $FILE_PATH file."
 fi

--- a/baseRefactoring.xml
+++ b/baseRefactoring.xml
@@ -1,6 +1,8 @@
 <application>
   <component name="BaseRefactoringSettings">
     <option name="SAFE_DELETE_WHEN_DELETE" value="false" />
+    <option name="RENAME_SEARCH_IN_COMMENTS_FOR_FILE" value="false" />
+    <option name="RENAME_SEARCH_FOR_TEXT_FOR_FILE" value="false" />
     <option name="RENAME_SEARCH_FOR_REFERENCES_FOR_FILE" value="false" />
     <option name="MOVE_SEARCH_FOR_REFERENCES_FOR_FILE" value="false" />
   </component>

--- a/codestyles/Default.xml
+++ b/codestyles/Default.xml
@@ -1,6 +1,13 @@
 <code_scheme name="Default" version="173">
   <option name="RIGHT_MARGIN" value="99" />
   <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
+  <option name="AUTODETECT_INDENTS" value="false" />
+  <option name="OTHER_INDENT_OPTIONS">
+    <value>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </value>
+  </option>
   <CMakeCodeStyleSettings>
     <option name="FORCE_COMMANDS_CASE" value="1" />
   </CMakeCodeStyleSettings>
@@ -65,9 +72,12 @@
     </extensions>
   </files>
   <codeStyleSettings language="CMake">
+    <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
+    <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
+    <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
       <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
@@ -87,7 +97,15 @@
     <option name="ASSIGNMENT_WRAP" value="1" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="XML">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
 </code_scheme>

--- a/colors/DarculaApexAI.icls
+++ b/colors/DarculaApexAI.icls
@@ -6,6 +6,15 @@
     <property name="modified">2020-06-25T18:19:36</property>
     <property name="originalScheme">DarculaApexAI</property>
   </metaInfo>
+  <option name="LINE_SPACING" value="1.1" />
+  <font>
+    <option name="EDITOR_FONT_NAME" value="DejaVu Sans Mono" />
+    <option name="EDITOR_FONT_SIZE" value="16" />
+  </font>
+  <font>
+    <option name="EDITOR_FONT_NAME" value="DialogInput" />
+    <option name="EDITOR_FONT_SIZE" value="16" />
+  </font>
   <attributes>
     <option name="DUPLICATE_FROM_SERVER">
       <value>

--- a/diff.xml
+++ b/diff.xml
@@ -3,6 +3,14 @@
     <option name="MIGRATE_OLD_SETTINGS" value="true" />
   </component>
   <component name="TextDiffSettings">
+    <option name="PLACES_MAP">
+      <entry key="CommitDialog">
+        <PlaceSettings>
+          <option name="EXPAND_BY_DEFAULT" value="true" />
+          <option name="READ_ONLY_LOCK" value="false" />
+        </PlaceSettings>
+      </entry>
+    </option>
     <option name="SHARED_SETTINGS">
       <SharedSettings>
         <option name="MERGE_AUTO_APPLY_NON_CONFLICTED_CHANGES" value="true" />

--- a/editor-font.xml
+++ b/editor-font.xml
@@ -5,5 +5,6 @@
     <option name="FONT_SIZE_2D" value="15.0" />
     <option name="FONT_FAMILY" value="DejaVu Sans Mono" />
     <option name="FONT_REGULAR_SUB_FAMILY" value="Book" />
+    <option name="SECONDARY_FONT_FAMILY" value="DialogInput" />
   </component>
 </application>

--- a/editor.xml
+++ b/editor.xml
@@ -3,6 +3,7 @@
     <option name="SOFT_WRAP_FILE_MASKS" value="*.md; *.txt; *.rst; *.adoc" />
     <option name="IS_WHEEL_FONTCHANGE_ENABLED" value="true" />
     <option name="IS_WHEEL_FONTCHANGE_PERSISTENT" value="true" />
+    <option name="RENAME_VARIABLES_INPLACE" value="false" />
     <option name="KEEP_TRAILING_SPACE_ON_CARET_LINE" value="false" />
   </component>
 </application>

--- a/filetypes.xml
+++ b/filetypes.xml
@@ -1,12 +1,13 @@
 <application>
-  <component name="FileTypeManager" version="18">
-    <ignoreFiles list="*.pyc;*.pyo;*.rbc;*.yarb;*~;.DS_Store;.git;.hg;.svn;CVS;__pycache__;_svn;bazel-bin;bazel-install;bazel-src;bazel-testlogs;vssver.scc;vssver2.scc" />
+  <component name="FileTypeManager" version="19">
+    <ignoreFiles list="*.pyc;*.pyo;*.rbc;*.yarb;*~;.DS_Store;.git;.hg;.mypy_cache;.pytest_cache;.ruff_cache;.svn;CVS;__pycache__;_svn;bazel-bin;bazel-install;bazel-src;bazel-testlogs;vssver.scc;vssver2.scc" />
     <extensionMap>
       <mapping ext="srcjar" type="ARCHIVE" />
       <mapping pattern="AMENT_IGNORE" type="AUTO_DETECTED" />
       <mapping pattern="launch_ros" type="AUTO_DETECTED" />
       <mapping pattern="ros2topic" type="AUTO_DETECTED" />
       <mapping pattern="Doxyfile" type="AUTO_DETECTED" />
+      <mapping ext="mcap" type="PLAIN_TEXT" />
       <mapping ext="idl" type="PLAIN_TEXT" />
       <mapping ext="msg" type="PLAIN_TEXT" />
       <mapping ext="srv" type="PLAIN_TEXT" />

--- a/find.xml
+++ b/find.xml
@@ -5,7 +5,6 @@
     <option name="SEARCH_SCOPE" value="All Places" />
     <mask>*.css</mask>
     <mask>*.html</mask>
-    <mask>*.xml</mask>
     <mask>*.cp</mask>
     <mask>*.inl</mask>
     <mask>*.ino</mask>
@@ -24,13 +23,19 @@
     <mask>*.tcc</mask>
     <mask>*.mm</mask>
     <mask>*.cc</mask>
-    <mask>*.h</mask>
-    <mask>*.c</mask>
-    <mask>*.hpp</mask>
-    <mask>*.cpp</mask>
-    <mask>*.txt</mask>
-    <mask>*.py</mask>
     <mask>BUILD</mask>
+    <mask>*.BUILD</mask>
+    <mask>*.yml</mask>
+    <mask>*.bzl</mask>
+    <mask>*.c</mask>
+    <mask>*.cfg</mask>
+    <mask>*.h</mask>
+    <mask>*.txt</mask>
+    <mask>*.hpp</mask>
     <mask>BUILD.bazel</mask>
+    <mask>*.cpp</mask>
+    <mask>*.py</mask>
+    <mask>*.xml</mask>
+    <mask>*.md</mask>
   </component>
 </application>

--- a/laf.xml
+++ b/laf.xml
@@ -1,5 +1,7 @@
 <application>
-  <component name="LafManager" autodetect="false">
-    <laf class-name="com.intellij.ide.ui.laf.darcula.DarculaLaf" />
+  <component name="LafManager">
+    <lafs-to-previous-schemes>
+      <laf-to-scheme laf="Darcula" scheme="DarculaApexAI" />
+    </lafs-to-previous-schemes>
   </component>
 </application>

--- a/templates/CMake.xml
+++ b/templates/CMake.xml
@@ -1,30 +1,22 @@
 <templateSet group="CMake">
   <template name="macro" value="macro($NAME$)&#10;    $END$&#10;endmacro()" description="new macro definition" toReformat="true" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true" />
-    <context />
   </template>
   <template name="function" value="function($NAME$)&#10;    $END$&#10;endfunction()" description="new function definition" toReformat="true" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true" />
-    <context />
   </template>
   <template name="if" value="if($CONDITION$)&#10;    $END$&#10;endif()" description="if()-condition" toReformat="true" toShortenFQNames="true">
     <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
   </template>
   <template name="foreach" value="foreach($CONDITION$)&#10;    $END$&#10;endforeach()" description="foreach()-loop" toReformat="true" toShortenFQNames="true">
     <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
   </template>
   <template name="while" value="while($CONDITION$)&#10;    $END$&#10;endwhile()" description="while()-loop" toReformat="true" toShortenFQNames="true">
     <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true" />
-    <context />
   </template>
-  <template name="boost" value="# see https://cmake.org/cmake/help/latest/module/FindBoost.html&#10;find_package(Boost REQUIRED)&#10;&#10;include_directories(${Boost_INCLUDE_DIR})" description="Add Boost headers" toReformat="true" toShortenFQNames="true">
-    <context />
-  </template>
+  <template name="boost" value="# see https://cmake.org/cmake/help/latest/module/FindBoost.html&#10;find_package(Boost REQUIRED)&#10;&#10;include_directories(${Boost_INCLUDE_DIR})" description="Add Boost headers" toReformat="true" toShortenFQNames="true" />
   <template name="boost_with_libs" value="# see https://cmake.org/cmake/help/latest/module/FindBoost.html&#10;find_package(Boost REQUIRED COMPONENTS $COMPS$)&#10;&#10;include_directories(${Boost_INCLUDE_DIR})&#10;# Note: a target should be already defined using 'add_executable' or 'add_library' &#10;target_link_libraries($TARGET$ ${Boost_LIBRARIES})&#10;" description="Add Boost headers and libraries" toReformat="true" toShortenFQNames="true">
     <variable name="COMPS" expression="" defaultValue="&quot;components you would like to link with&quot;" alwaysStopAt="true" />
     <variable name="TARGET" expression="" defaultValue="&quot;TargetName&quot;" alwaysStopAt="true" />
-    <context />
   </template>
 </templateSet>

--- a/tools/External Tools.xml
+++ b/tools/External Tools.xml
@@ -16,8 +16,8 @@
   <tool name="Doc linters" description="Run apex_doc_lint" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
     <exec>
       <option name="COMMAND" value="../.doc_scripts/apex_doc_lint" />
-      <option name="PARAMETERS" value="--ci --code-block --private-links --symlinks --spelling --md" />
-      <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+      <option name="PARAMETERS" value="--ci --symlinks --spelling --md" />
+      <option name="WORKING_DIRECTORY" value="$WorkspaceRoot$" />
     </exec>
   </tool>
   <tool name="Doc linters Bazel" description="Run apex_doc_lint" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">

--- a/vcs.xml
+++ b/vcs.xml
@@ -6,10 +6,19 @@
         <option value="Default.Subject" />
         <option value="Default.Author" />
         <option value="Default.Date" />
+        <option value="GitHub.CommitStatus" />
       </list>
     </option>
+    <option name="COLUMN_ID_VISIBILITY">
+      <map>
+        <entry key="Table.Default.Author.ColumnIdVisibility" value="true" />
+        <entry key="Table.Default.Date.ColumnIdVisibility" value="true" />
+      </map>
+    </option>
+    <option name="SHOW_CHANGES_FROM_PARENTS" value="true" />
   </component>
   <component name="VcsApplicationSettings">
+    <option name="DETECT_PATCH_ON_THE_FLY" value="true" />
     <option name="CREATE_CHANGELISTS_AUTOMATICALLY" value="true" />
     <option name="COMMIT_FROM_LOCAL_CHANGES" value="false" />
   </component>


### PR DESCRIPTION
1. Fix for failing Axivion tool run. Add missing `:all` for targets when running Axivion. 
1. Add `--test_verbose_timeout_warnings` flag to the `bazel test` button.
1. Update settings for the version control panel.
   - Detect patch on the fly when it is copied in the clipboard buffer.
   - Add `Author` and `Date` column to be shown by default.
1. Expand the changes tree and allow to make edits in the commit dialog directly.
1. Update refactoring settings.
   - Disable rename search in comments and text files. Also, disable renaming in place.
1. Use DarculaApexAI scheme by default.
1. Update the default font to be `DejaVu Sans Mono` and the fallback font to be a system `DialogInput`
1. Remove `--code-block`, `--private-links` from `apex_doc_lint` command
   - Rationale: `--code-block` and `--private-links` are not fully supported yet in a new version of our `apex_doc_lint` and don't check on CI.
1. Remove `<context />` tags in the CMake.xml. Seems autoupdate from a new version of CLion.
1. Update find.xml. Add BUILD.bazel, *.md and *.cfg files.
1. Update filetypes.xml file.
   - Add mcap as a text file. Also, add python cache files to exclusions.
1. Updated indents for tabs and CMake. 
   - Enforce the use of 2 spaces for tabs, including CMake files.